### PR TITLE
Migrate client-side ML: TFJS (WebGL) → LiteRT.js (Wasm/XNNPack)

### DIFF
--- a/mobile-app/app/src/main/java/com/unidagontor/retakid/data/ml/MLAnalyzer.kt
+++ b/mobile-app/app/src/main/java/com/unidagontor/retakid/data/ml/MLAnalyzer.kt
@@ -74,10 +74,6 @@ class TFLiteMLAnalyzer(private val context: Context) : MLAnalyzer {
             val maxIdx = probs.indices.maxByOrNull { probs[it] } ?: 0
             val confidence = probs[maxIdx]
 
-            if (confidence < 0.4f) {
-                return@withContext MLResult(DetectionResult.AMAN, confidence)
-            }
-
             val result = when (maxIdx) {
                 0 -> DetectionResult.AMAN
                 1 -> DetectionResult.WASPADA

--- a/mobile-app/app/src/main/java/com/unidagontor/retakid/ui/screens/MainScreens.kt
+++ b/mobile-app/app/src/main/java/com/unidagontor/retakid/ui/screens/MainScreens.kt
@@ -87,9 +87,11 @@ fun DeteksiTab(vm: DeteksiViewModel = viewModel()) {
             }
             DeteksiStage.RESULT -> {
                 val displayResult = state.riskFactorReport?.finalResult ?: state.mlResult?.detectionResult
+                val displayConfidence = state.mlResult?.confidence ?: 0f
                 if (displayResult != null) {
                     ResultView(
                         result = displayResult,
+                        confidence = displayConfidence,
                         report = state.riskFactorReport,
                         image = state.capturedImage,
                         onProceed = { vm.proceedToReport() },
@@ -281,6 +283,7 @@ fun AnalyzingEnvView() {
 @Composable
 fun ResultView(
     result: DetectionResult,
+    confidence: Float,
     report: com.unidagontor.retakid.data.risk.RiskFactorReport?,
     image: Bitmap?,
     onProceed: () -> Unit,
@@ -347,6 +350,50 @@ fun ResultView(
                     textAlign = TextAlign.Center,
                     modifier = Modifier.fillMaxWidth()
                 )
+            }
+        }
+
+        if (confidence < 0.4f) {
+            Spacer(modifier = Modifier.height(12.dp))
+            Surface(
+                color = StatusBahaya.copy(alpha = 0.15f),
+                shape = RoundedCornerShape(12.dp),
+                modifier = Modifier.fillMaxWidth()
+            ) {
+                Row(
+                    modifier = Modifier.padding(12.dp),
+                    verticalAlignment = Alignment.CenterVertically
+                ) {
+                    Icon(Icons.Default.Warning, contentDescription = null, tint = StatusBahaya)
+                    Spacer(modifier = Modifier.width(12.dp))
+                    Text(
+                        "Gambar bukan retakan tanah? Pastikan memotret permukaan tanah",
+                        color = StatusBahaya,
+                        fontSize = 12.sp,
+                        fontWeight = FontWeight.Medium
+                    )
+                }
+            }
+        } else if (confidence < 0.6f) {
+            Spacer(modifier = Modifier.height(12.dp))
+            Surface(
+                color = StatusWaspada.copy(alpha = 0.15f),
+                shape = RoundedCornerShape(12.dp),
+                modifier = Modifier.fillMaxWidth()
+            ) {
+                Row(
+                    modifier = Modifier.padding(12.dp),
+                    verticalAlignment = Alignment.CenterVertically
+                ) {
+                    Icon(Icons.Default.Info, contentDescription = null, tint = StatusWaspada)
+                    Spacer(modifier = Modifier.width(12.dp))
+                    Text(
+                        "Hasil tidak pasti — ambil foto ulang dengan pencahayaan lebih baik",
+                        color = StatusWaspada,
+                        fontSize = 12.sp,
+                        fontWeight = FontWeight.Medium
+                    )
+                }
             }
         }
 

--- a/web-app/src/pages/ReportFormPage.tsx
+++ b/web-app/src/pages/ReportFormPage.tsx
@@ -27,6 +27,9 @@ const STATUS_OPTIONS: { value: ReportStatus; label: string; desc: string; detail
   { value: 'BAHAYA', label: 'Bahaya', desc: 'Retakan kritis, segera evakuasi', detail: 'Hubungi BPBD segera' },
 ];
 
+const CONFIDENCE_THRESHOLD_LOW = 0.4;
+const CONFIDENCE_THRESHOLD_MEDIUM = 0.6;
+
 const CONFIDENCE_COLORS: Record<ReportStatus, string> = {
   AMAN: 'bg-aman-bg text-aman border-aman/30',
   WASPADA: 'bg-waspada-bg text-waspada border-waspada/30',
@@ -219,11 +222,25 @@ export function ReportFormPage() {
                   Deteksi otomatis gagal. Pilih manual di bawah.
                 </div>
               ) : predictionConfidence != null ? (
-                <div className={`flex items-center gap-2 rounded-xl border px-3.5 py-2.5 text-xs ${CONFIDENCE_COLORS[form.status]}`}>
-                  <Cpu className="h-3.5 w-3.5 shrink-0" />
-                  AI mendeteksi: <strong>{STATUS_OPTIONS.find(s => s.value === form.status)?.label}</strong>
-                  {' '}({(predictionConfidence * 100).toFixed(0)}% yakin)
-                  <span className="ml-auto text-[10px] opacity-60">Override manual di bawah</span>
+                <div className="space-y-2">
+                  <div className={`flex items-center gap-2 rounded-xl border px-3.5 py-2.5 text-xs ${CONFIDENCE_COLORS[form.status]}`}>
+                    <Cpu className="h-3.5 w-3.5 shrink-0" />
+                    AI mendeteksi: <strong>{STATUS_OPTIONS.find(s => s.value === form.status)?.label}</strong>
+                    {' '}({(predictionConfidence * 100).toFixed(0)}% yakin)
+                    <span className="ml-auto text-[10px] opacity-60">Override manual di bawah</span>
+                  </div>
+                  {predictionConfidence < CONFIDENCE_THRESHOLD_LOW && (
+                    <div className="flex items-start gap-2 rounded-xl bg-bahaya-bg/70 border border-bahaya/20 px-3.5 py-2.5 text-xs text-bahaya">
+                      <AlertCircle className="h-3.5 w-3.5 shrink-0 mt-0.5" />
+                      <span>Gambar bukan retakan tanah? Pastikan memotret permukaan tanah</span>
+                    </div>
+                  )}
+                  {predictionConfidence >= CONFIDENCE_THRESHOLD_LOW && predictionConfidence < CONFIDENCE_THRESHOLD_MEDIUM && (
+                    <div className="flex items-start gap-2 rounded-xl bg-waspada-bg/70 border border-waspada/20 px-3.5 py-2.5 text-xs text-waspada">
+                      <AlertCircle className="h-3.5 w-3.5 shrink-0 mt-0.5" />
+                      <span>Hasil tidak pasti — ambil foto ulang dengan pencahayaan lebih baik</span>
+                    </div>
+                  )}
                 </div>
               ) : !isModelReady && modelError ? (
                 <div className="flex items-center gap-2 rounded-xl bg-waspada-bg border border-waspada/20 px-3.5 py-2.5 text-xs text-waspada">


### PR DESCRIPTION
## Summary
- Replace @tensorflow/tfjs (141MB) with @litertjs/core (75KB) — native .tflite via WebAssembly
- Serve LiteRT Wasm files from /wasm/ with PWA caching (30 days)
- Rewrite useModelInference + preprocess for LiteRT Tensor API
- Remove TFJS GraphModel conversion — deploy script is now simple `cp`
- Lazy-load ReportFormPage + Wasm only loads when visiting /reports/new
- Add confidence threshold warnings (<40% uncertain, <60% retake) in report form

Closes #85, #89