### PR TITLE
CS6: Profil pengguna + Firebase→Supabase migration

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,56 @@
+name: Build & Release APK
+
+on:
+  push:
+    tags:
+      - "v*"
+
+jobs:
+  build:
+    name: Build Release APK
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up JDK 17
+        uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: 17
+
+      - name: Setup Gradle
+        uses: gradle/actions/setup-gradle@v4
+
+      - name: Build release APK
+        run: |
+          cd mobile-app
+          chmod +x gradlew
+          ./gradlew assembleRelease
+        env:
+          RELEASE_STORE_FILE: ${{ secrets.RELEASE_STORE_FILE }}
+          RELEASE_STORE_PASSWORD: ${{ secrets.RELEASE_STORE_PASSWORD }}
+          RELEASE_KEY_ALIAS: ${{ secrets.RELEASE_KEY_ALIAS }}
+          RELEASE_KEY_PASSWORD: ${{ secrets.RELEASE_KEY_PASSWORD }}
+
+      - name: Rename APK
+        run: |
+          mv mobile-app/app/build/outputs/apk/release/app-release.apk \
+             mobile-app/app/build/outputs/apk/release/retakid-v1.1.0.apk
+
+      - name: Create Release
+        uses: softprops/action-gh-release@v2
+        with:
+          name: RetakID v1.1.0
+          body: |
+            ## RetakID v1.1.0
+
+            ### Changes
+            - Multi-factor risk assessment system
+            - Real-time landslide detection with TensorFlow Lite
+            - GPS & elevation integration
+            - Firebase syncing
+
+            ### Installation
+            Download `retakid-v1.1.0.apk` and install on your Android device.
+          files: mobile-app/app/build/outputs/apk/release/retakid-v1.1.0.apk

--- a/mobile-app/app/build.gradle.kts
+++ b/mobile-app/app/build.gradle.kts
@@ -94,6 +94,8 @@ dependencies {
     implementation("com.google.android.gms:play-services-location:21.2.0")
 //    TensorFlow Lite (raw Interpreter — no metadata dependency)
     implementation("org.tensorflow:tensorflow-lite:2.16.1")
+//    EXIF
+    implementation("androidx.exifinterface:exifinterface:1.3.7")
 //    CameraX
     implementation("androidx.camera:camera-camera2:1.3.3")
     implementation("androidx.camera:camera-lifecycle:1.3.3")

--- a/mobile-app/app/build.gradle.kts
+++ b/mobile-app/app/build.gradle.kts
@@ -16,19 +16,32 @@ android {
         applicationId = "com.unidagontor.retakid"
         minSdk = 24
         targetSdk = 36
-        versionCode = 1
-        versionName = "1.0"
+        versionCode = 2
+        versionName = "1.1.0"
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
     }
 
+    signingConfigs {
+        create("release") {
+            storeFile = file(System.getenv("RELEASE_STORE_FILE") ?: "../debug.keystore")
+            storePassword = System.getenv("RELEASE_STORE_PASSWORD") ?: "android"
+            keyAlias = System.getenv("RELEASE_KEY_ALIAS") ?: "androiddebugkey"
+            keyPassword = System.getenv("RELEASE_KEY_PASSWORD") ?: "android"
+        }
+    }
+
     buildTypes {
         release {
-            isMinifyEnabled = false
+            isMinifyEnabled = true
             proguardFiles(
                 getDefaultProguardFile("proguard-android-optimize.txt"),
                 "proguard-rules.pro"
             )
+            signingConfig = signingConfigs.getByName("release")
+        }
+        debug {
+            isMinifyEnabled = false
         }
     }
     compileOptions {

--- a/mobile-app/app/build.gradle.kts
+++ b/mobile-app/app/build.gradle.kts
@@ -102,12 +102,12 @@ dependencies {
     implementation("androidx.camera:camera-view:1.3.3")
 //Google Sign-In
     implementation("com.google.android.gms:play-services-auth:21.2.0")
-//    Firebase
-    implementation(platform("com.google.firebase:firebase-bom:32.7.4"))
-    implementation("com.google.firebase:firebase-auth-ktx")
-    implementation("com.google.firebase:firebase-firestore-ktx")
-    implementation("com.google.firebase:firebase-storage-ktx")
-    implementation("com.google.firebase:firebase-messaging-ktx")
-    implementation("com.google.firebase:firebase-analytics")
+//    Supabase
+    implementation(platform(libs.supabase.bom))
+    implementation(libs.supabase.common)
+    implementation(libs.supabase.auth)
+    implementation(libs.supabase.postgrest)
+    implementation(libs.supabase.storage)
+    implementation(libs.supabase.realtime)
 
 }

--- a/mobile-app/app/build.gradle.kts
+++ b/mobile-app/app/build.gradle.kts
@@ -1,7 +1,6 @@
 plugins {
     alias(libs.plugins.android.application)
     alias(libs.plugins.kotlin.compose)
-    id("com.google.gms.google-services")
 }
 
 android {

--- a/mobile-app/app/proguard-rules.pro
+++ b/mobile-app/app/proguard-rules.pro
@@ -19,3 +19,31 @@
 # If you keep the line number information, uncomment this to
 # hide the original source file name.
 #-renamesourcefileattribute SourceFile
+
+# TensorFlow Lite
+-keep class org.tensorflow.lite.** { *; }
+-keep class org.tensorflow.lite.gpu.** { *; }
+-dontwarn org.tensorflow.lite.**
+
+# Firebase
+-keep class com.google.firebase.** { *; }
+-keep class com.google.android.gms.** { *; }
+-dontwarn com.google.firebase.**
+-dontwarn com.google.android.gms.**
+
+# Data classes for Firestore
+-keep class com.unidagontor.retakid.data.** { *; }
+-keep class com.unidagontor.retakid.ui.viewmodel.** { *; }
+
+# Kotlin Coroutines
+-keepnames class kotlinx.coroutines.internal.MainDispatcherFactory {}
+-keepnames class kotlinx.coroutines.CoroutineExceptionHandler {}
+-dontwarn kotlinx.coroutines.**
+
+# OSMDroid
+-dontwarn org.osmdroid.**
+-keep class org.osmdroid.** { *; }
+
+# Keep Retrofit/OkHttp if used
+-dontwarn okhttp3.**
+-dontwarn retrofit2.**

--- a/mobile-app/app/proguard-rules.pro
+++ b/mobile-app/app/proguard-rules.pro
@@ -25,13 +25,11 @@
 -keep class org.tensorflow.lite.gpu.** { *; }
 -dontwarn org.tensorflow.lite.**
 
-# Firebase
--keep class com.google.firebase.** { *; }
+# Google Play Services (Location, Auth)
 -keep class com.google.android.gms.** { *; }
--dontwarn com.google.firebase.**
 -dontwarn com.google.android.gms.**
 
-# Data classes for Firestore
+# Data classes for serialization
 -keep class com.unidagontor.retakid.data.** { *; }
 -keep class com.unidagontor.retakid.ui.viewmodel.** { *; }
 

--- a/mobile-app/app/src/main/AndroidManifest.xml
+++ b/mobile-app/app/src/main/AndroidManifest.xml
@@ -13,6 +13,7 @@
         tools:ignore="PhotoAndVideoPolicy" />
     <uses-permission android:name="android.permission.ACCESS_FINE_LOCATION" />
     <uses-permission android:name="android.permission.ACCESS_COARSE_LOCATION" />
+    <uses-permission android:name="android.permission.POST_NOTIFICATIONS" />
     <application
         android:allowBackup="true"
         android:dataExtractionRules="@xml/data_extraction_rules"

--- a/mobile-app/app/src/main/java/com/unidagontor/retakid/Retakidapplication.kt
+++ b/mobile-app/app/src/main/java/com/unidagontor/retakid/Retakidapplication.kt
@@ -2,13 +2,15 @@ package com.unidagontor.retakid
 
 import android.app.Application
 import com.unidagontor.retakid.data.SupabaseClient
+import com.unidagontor.retakid.data.notification.BahayaRealtimeListener
+import com.unidagontor.retakid.data.notification.NotificationHelper
 
 
 class RetakIdApplication : Application() {
     override fun onCreate() {
         super.onCreate()
-        // Init Supabase client sekali saat app start
-        // Session tersimpan otomatis ke SharedPreferences
         SupabaseClient.init(this)
+        NotificationHelper.createChannel(this)
+        BahayaRealtimeListener.start(this)
     }
 }

--- a/mobile-app/app/src/main/java/com/unidagontor/retakid/data/notification/BahayaRealtimeListener.kt
+++ b/mobile-app/app/src/main/java/com/unidagontor/retakid/data/notification/BahayaRealtimeListener.kt
@@ -1,0 +1,66 @@
+package com.unidagontor.retakid.data.notification
+
+import android.content.Context
+import com.unidagontor.retakid.data.SupabaseClient
+import io.github.jan.supabase.realtime.PostgresAction
+import io.github.jan.supabase.realtime.postgresChangeFlow
+import io.github.jan.supabase.realtime.realtime
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.launch
+
+object BahayaRealtimeListener {
+
+    private val scope = CoroutineScope(SupervisorJob() + Dispatchers.IO)
+    private var isListening = false
+
+    fun start(context: Context) {
+        if (isListening) return
+        isListening = true
+
+        scope.launch {
+            try {
+                SupabaseClient.client.realtime.connect()
+            } catch (_: Exception) {
+                return@launch
+            }
+
+            try {
+                SupabaseClient.client.realtime.channel("bahaya-alerts")
+                    .postgresChangeFlow<PostgresAction.Insert>(schema = "public") {
+                        table = "laporan"
+                    }
+                    .collect { action ->
+                        val record = action.record
+                        val status = record["status"]?.toString()
+                        if (status != "BAHAYA") return@collect
+
+                        val id = record["id"]?.toString() ?: return@collect
+                        val lokasi = record["nama_lokasi"]?.toString() ?: "Tidak diketahui"
+                        val lat = (record["latitude"] as? Number)?.toDouble() ?: 0.0
+                        val lon = (record["longitude"] as? Number)?.toDouble() ?: 0.0
+
+                        NotificationHelper.showBahayaNotification(
+                            context = context,
+                            id = id,
+                            lokasi = lokasi,
+                            lat = lat,
+                            lon = lon
+                        )
+                    }
+            } catch (_: Exception) {
+                isListening = false
+            }
+        }
+    }
+
+    fun stop() {
+        if (!isListening) return
+        isListening = false
+
+        try {
+            SupabaseClient.client.realtime.removeChannel("bahaya-alerts")
+        } catch (_: Exception) { }
+    }
+}

--- a/mobile-app/app/src/main/java/com/unidagontor/retakid/data/notification/NotificationHelper.kt
+++ b/mobile-app/app/src/main/java/com/unidagontor/retakid/data/notification/NotificationHelper.kt
@@ -1,0 +1,69 @@
+package com.unidagontor.retakid.data.notification
+
+import android.Manifest
+import android.app.NotificationChannel
+import android.app.NotificationManager
+import android.app.PendingIntent
+import android.content.Context
+import android.content.Intent
+import android.content.pm.PackageManager
+import android.os.Build
+import androidx.core.app.NotificationCompat
+import androidx.core.app.NotificationManagerCompat
+import androidx.core.content.ContextCompat
+import com.unidagontor.retakid.MainActivity
+import com.unidagontor.retakid.R
+
+private const val CHANNEL_ID = "bahaya_alerts"
+private const val CHANNEL_NAME = "Peringatan BAHAYA"
+private const val CHANNEL_DESC = "Notifikasi ketika laporan BAHAYA masuk"
+
+object NotificationHelper {
+
+    fun createChannel(context: Context) {
+        val channel = NotificationChannel(
+            CHANNEL_ID,
+            CHANNEL_NAME,
+            NotificationManager.IMPORTANCE_HIGH
+        ).apply {
+            description = CHANNEL_DESC
+        }
+        val nm = context.getSystemService(Context.NOTIFICATION_SERVICE) as NotificationManager
+        nm.createNotificationChannel(channel)
+    }
+
+    fun hasPermission(context: Context): Boolean {
+        return if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
+            ContextCompat.checkSelfPermission(
+                context, Manifest.permission.POST_NOTIFICATIONS
+            ) == PackageManager.PERMISSION_GRANTED
+        } else true
+    }
+
+    fun showBahayaNotification(context: Context, id: String, lokasi: String, lat: Double, lon: Double) {
+        if (!hasPermission(context)) return
+
+        val intent = Intent(context, MainActivity::class.java).apply {
+            flags = Intent.FLAG_ACTIVITY_NEW_TASK or Intent.FLAG_ACTIVITY_CLEAR_TOP
+            putExtra("laporan_id", id)
+        }
+
+        val pendingIntent = PendingIntent.getActivity(
+            context, id.hashCode(), intent,
+            PendingIntent.FLAG_UPDATE_CURRENT or PendingIntent.FLAG_IMMUTABLE
+        )
+
+        val notification = NotificationCompat.Builder(context, CHANNEL_ID)
+            .setSmallIcon(R.drawable.ic_launcher_foreground)
+            .setContentTitle("Laporan BAHAYA Baru")
+            .setContentText("Retakan tanah terdeteksi di $lokasi")
+            .setStyle(NotificationCompat.BigTextStyle()
+                .bigText("Status: BAHAYA\nLokasi: $lokasi\nKoordinat: ${"%.6f".format(lat)}, ${"%.6f".format(lon)}"))
+            .setPriority(NotificationCompat.PRIORITY_HIGH)
+            .setAutoCancel(true)
+            .setContentIntent(pendingIntent)
+            .build()
+
+        NotificationManagerCompat.from(context).notify(id.hashCode(), notification)
+    }
+}

--- a/mobile-app/app/src/main/java/com/unidagontor/retakid/data/photo/ExifData.kt
+++ b/mobile-app/app/src/main/java/com/unidagontor/retakid/data/photo/ExifData.kt
@@ -1,0 +1,8 @@
+package com.unidagontor.retakid.data.photo
+
+data class ExifData(
+    val latitude: Double?,
+    val longitude: Double?,
+    val altitudeMeters: Double?,
+    val timestamp: String?
+)

--- a/mobile-app/app/src/main/java/com/unidagontor/retakid/data/photo/ExifReader.kt
+++ b/mobile-app/app/src/main/java/com/unidagontor/retakid/data/photo/ExifReader.kt
@@ -1,0 +1,24 @@
+package com.unidagontor.retakid.data.photo
+
+import androidx.exifinterface.media.ExifInterface
+
+object ExifReader {
+
+    fun read(filePath: String): ExifData? {
+        return try {
+            val exif = ExifInterface(filePath)
+
+            val latLng = exif.latLong
+            val altitude = exif.getAltitude(Double.NaN)
+
+            ExifData(
+                latitude = latLng?.getOrNull(0),
+                longitude = latLng?.getOrNull(1),
+                altitudeMeters = if (altitude.isNaN()) null else altitude,
+                timestamp = exif.getAttribute(ExifInterface.TAG_DATETIME_ORIGINAL)
+            )
+        } catch (_: Exception) {
+            null
+        }
+    }
+}

--- a/mobile-app/app/src/main/java/com/unidagontor/retakid/ui/screens/AppNavigation.kt
+++ b/mobile-app/app/src/main/java/com/unidagontor/retakid/ui/screens/AppNavigation.kt
@@ -40,13 +40,25 @@ fun RetakIdApp() {
             LoginScreen(onLoginSuccess = { navController.navigate("main") { popUpTo("login") { inclusive = true } } })
         }
         composable("main") {
-            MainContainerScreen() // Memanggil Scaffold 4 Tab
+            MainContainerScreen(
+                onNavigateToDetail = { laporanId -> navController.navigate("detail/$laporanId") }
+            )
+        }
+        composable("detail/{laporanId}") { backStackEntry ->
+            val laporanId = backStackEntry.arguments?.getString("laporanId") ?: return@composable
+            DetailLaporanScreen(
+                laporanId = laporanId,
+                onBack = { navController.popBackStack() },
+                onConfirm = {
+                    navController.popBackStack()
+                }
+            )
         }
     }
 }
 
 @Composable
-fun MainContainerScreen() {
+fun MainContainerScreen(onNavigateToDetail: (String) -> Unit = {}) {
     val bottomNavController = rememberNavController()
     val items = listOf(BottomNav.Beranda, BottomNav.Deteksi, BottomNav.Peta, BottomNav.Profil)
     val navBackStackEntry by bottomNavController.currentBackStackEntryAsState()
@@ -82,7 +94,7 @@ fun MainContainerScreen() {
             startDestination = BottomNav.Beranda.route,
             modifier = Modifier.padding(innerPadding)
         ) {
-            composable(BottomNav.Beranda.route) { BerandaTab() }
+            composable(BottomNav.Beranda.route) { BerandaTab(onLaporanClick = onNavigateToDetail) }
             composable(BottomNav.Deteksi.route) { DeteksiTab() }
             composable(BottomNav.Peta.route) { PetaTab() }
             composable(BottomNav.Profil.route) { ProfilTab() }

--- a/mobile-app/app/src/main/java/com/unidagontor/retakid/ui/screens/AppNavigation.kt
+++ b/mobile-app/app/src/main/java/com/unidagontor/retakid/ui/screens/AppNavigation.kt
@@ -97,7 +97,18 @@ fun MainContainerScreen(onNavigateToDetail: (String) -> Unit = {}) {
             composable(BottomNav.Beranda.route) { BerandaTab(onLaporanClick = onNavigateToDetail) }
             composable(BottomNav.Deteksi.route) { DeteksiTab() }
             composable(BottomNav.Peta.route) { PetaTab() }
-            composable(BottomNav.Profil.route) { ProfilTab() }
+            composable(BottomNav.Profil.route) {
+                ProfilTab(
+                    onSignOut = {
+                        navController.navigate("login") {
+                            popUpTo(navController.graph.startDestinationId) { inclusive = true }
+                        }
+                    },
+                    onRiwayatClick = { laporanId ->
+                        onNavigateToDetail(laporanId)
+                    }
+                )
+            }
         }
     }
 }

--- a/mobile-app/app/src/main/java/com/unidagontor/retakid/ui/screens/AuthScreens.kt
+++ b/mobile-app/app/src/main/java/com/unidagontor/retakid/ui/screens/AuthScreens.kt
@@ -1,6 +1,5 @@
 package com.unidagontor.retakid.ui.screens
 
-import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.*
 import androidx.compose.material3.*
 import androidx.compose.runtime.*
@@ -11,22 +10,7 @@ import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
-import kotlinx.coroutines.delay
-import com.unidagontor.retakid.ui.theme.GreenPrimary // Sesuaikan package Anda
-
-@Composable
-fun SplashScreen(onSplashFinished: () -> Unit) {
-    LaunchedEffect(Unit) {
-        delay(2000) // Tampil 2 detik lalu pindah
-        onSplashFinished()
-    }
-    Box(
-        modifier = Modifier.fillMaxSize().background(GreenPrimary),
-        contentAlignment = Alignment.Center
-    ) {
-        Text("Retak.id", color = Color.White, fontSize = 40.sp, fontWeight = FontWeight.Bold)
-    }
-}
+import com.unidagontor.retakid.ui.theme.GreenPrimary
 
 @Composable
 fun OnboardingScreen(onFinishOnboarding: () -> Unit) {

--- a/mobile-app/app/src/main/java/com/unidagontor/retakid/ui/screens/BerandaScreen.kt
+++ b/mobile-app/app/src/main/java/com/unidagontor/retakid/ui/screens/BerandaScreen.kt
@@ -20,7 +20,7 @@ import androidx.lifecycle.viewmodel.compose.viewModel
 import com.unidagontor.retakid.ui.viewmodel.BerandaViewModel
 import com.unidagontor.retakid.ui.theme.*
 
-// ─── Data model (nanti dari Firestore) ────────────────
+// ─── Data model (dari Supabase `laporan` table) ───────
 data class LaporanItem(
     val id: String,
     val namaLokasi: String,

--- a/mobile-app/app/src/main/java/com/unidagontor/retakid/ui/screens/BerandaScreen.kt
+++ b/mobile-app/app/src/main/java/com/unidagontor/retakid/ui/screens/BerandaScreen.kt
@@ -24,15 +24,21 @@ import com.unidagontor.retakid.ui.theme.*
 data class LaporanItem(
     val id: String,
     val namaLokasi: String,
-    val status: String,          // "AMAN" | "WASPADA" | "BAHAYA"
+    val status: String,
     val catatan: String,
+    val fotoUrl: String? = null,
+    val latitude: Double = 0.0,
+    val longitude: Double = 0.0,
     val timestamp: String,
     val pelapor: String,
-    val terverifikasi: Int       // jumlah konfirmasi warga
+    val terverifikasi: Int
 )
 
 @Composable
-fun BerandaTab(viewModel: BerandaViewModel = viewModel()) {
+fun BerandaTab(
+    onLaporanClick: (String) -> Unit = {},
+    viewModel: BerandaViewModel = viewModel()
+) {
     val uiState by viewModel.uiState.collectAsState()
 
     Column(modifier = Modifier.fillMaxSize().background(Surface)) {
@@ -63,7 +69,7 @@ fun BerandaTab(viewModel: BerandaViewModel = viewModel()) {
                     )
                 }
                 items(uiState.laporanList) { laporan ->
-                    LaporanCard(laporan = laporan)
+                    LaporanCard(laporan = laporan, onClick = { onLaporanClick(laporan.id) })
                 }
             }
         }
@@ -127,7 +133,7 @@ fun StatChip(count: Int, label: String, color: Color, bg: Color) {
 
 
 @Composable
-fun LaporanCard(laporan: LaporanItem) {
+fun LaporanCard(laporan: LaporanItem, onClick: () -> Unit = {}) {
     val (statusBg, statusColor) = when (laporan.status) {
         "BAHAYA"  -> StatusBahayaBg  to StatusBahaya
         "WASPADA" -> StatusWaspadaBg to StatusWaspada
@@ -138,7 +144,8 @@ fun LaporanCard(laporan: LaporanItem) {
         modifier  = Modifier.fillMaxWidth(),
         shape     = RoundedCornerShape(14.dp),
         colors    = CardDefaults.cardColors(containerColor = CardBg),
-        elevation = CardDefaults.cardElevation(2.dp)
+        elevation = CardDefaults.cardElevation(2.dp),
+        onClick   = onClick
     ) {
         // Garis warna status di sisi kiri
         Row(modifier = Modifier.height(IntrinsicSize.Min)) {

--- a/mobile-app/app/src/main/java/com/unidagontor/retakid/ui/screens/DetailLaporanScreen.kt
+++ b/mobile-app/app/src/main/java/com/unidagontor/retakid/ui/screens/DetailLaporanScreen.kt
@@ -21,10 +21,10 @@ import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import coil.compose.AsyncImage
 import coil.request.ImageRequest
-import com.google.firebase.firestore.FieldValue
-import com.google.firebase.firestore.FirebaseFirestore
+import com.unidagontor.retakid.data.SupabaseClient
 import com.unidagontor.retakid.ui.theme.*
-import kotlinx.coroutines.tasks.await
+import com.unidagontor.retakid.ui.viewmodel.LaporanDto
+import io.github.jan.supabase.postgrest.from
 import java.text.SimpleDateFormat
 import java.util.*
 import kotlinx.coroutines.launch
@@ -43,33 +43,22 @@ fun DetailLaporanScreen(
 
     LaunchedEffect(laporanId) {
         try {
-            val doc = FirebaseFirestore.getInstance()
-                .collection("laporan")
-                .document(laporanId)
-                .get()
-                .await()
+            val result = SupabaseClient.client.from("laporan")
+                .select { filter { eq("id", laporanId) } }
+                .decodeSingle<LaporanDto>()
 
-            if (doc.exists()) {
-                val timestampLong = doc.get("timestamp")?.let {
-                    when (it) { is Long -> it; is Double -> it.toLong(); else -> 0L }
-                } ?: 0L
-                val terverifikasi = doc.get("terverifikasi")?.let {
-                    when (it) { is Long -> it.toInt(); is Double -> it.toInt(); else -> 0 }
-                } ?: 0
-
-                laporan = LaporanItem(
-                    id = doc.id,
-                    namaLokasi = doc.getString("namaLokasi") ?: "Tanpa Nama",
-                    status = doc.getString("status") ?: "AMAN",
-                    catatan = doc.getString("catatan") ?: "",
-                    fotoUrl = doc.getString("foto_url"),
-                    latitude = doc.getDouble("latitude") ?: 0.0,
-                    longitude = doc.getDouble("longitude") ?: 0.0,
-                    timestamp = formatDetailTimestamp(timestampLong),
-                    pelapor = doc.getString("pelapor") ?: "User",
-                    terverifikasi = terverifikasi
-                )
-            }
+            laporan = LaporanItem(
+                id = result.id,
+                namaLokasi = result.namaLokasi,
+                status = result.status,
+                catatan = result.catatan,
+                fotoUrl = result.fotoUrl,
+                latitude = result.latitude,
+                longitude = result.longitude,
+                timestamp = formatDetailTimestamp(parseIsoTimestamp(result.createdAt)),
+                pelapor = result.pelapor,
+                terverifikasi = result.terverifikasi
+            )
         } catch (_: Exception) { }
         isLoading = false
     }
@@ -103,11 +92,13 @@ fun DetailLaporanScreen(
                     isConfirming = true
                     scope.launch {
                         try {
-                            FirebaseFirestore.getInstance()
-                                .collection("laporan")
-                                .document(laporanId)
-                                .update("terverifikasi", FieldValue.increment(1))
-                                .await()
+                            val supabase = SupabaseClient.client
+                            val current = supabase.from("laporan")
+                                .select { filter { eq("id", laporanId) } }
+                                .decodeSingle<LaporanDto>()
+                            supabase.from("laporan").update({
+                                "terverifikasi" to (current.terverifikasi + 1)
+                            }) { filter { eq("id", laporanId) } }
                         } catch (_: Exception) { }
                         onConfirm()
                     }
@@ -265,6 +256,13 @@ private fun DetailInfoRow(
             Text(value, fontSize = 14.sp, color = TextPrimary, fontWeight = FontWeight.Medium)
         }
     }
+}
+
+private fun parseIsoTimestamp(iso: String): Long {
+    return try {
+        val sdf = SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss", Locale.getDefault())
+        sdf.parse(iso.take(19))?.time ?: 0L
+    } catch (_: Exception) { 0L }
 }
 
 private fun formatDetailTimestamp(timestamp: Long): String {

--- a/mobile-app/app/src/main/java/com/unidagontor/retakid/ui/screens/DetailLaporanScreen.kt
+++ b/mobile-app/app/src/main/java/com/unidagontor/retakid/ui/screens/DetailLaporanScreen.kt
@@ -1,0 +1,274 @@
+package com.unidagontor.retakid.ui.screens
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.*
+import androidx.compose.material3.*
+import androidx.compose.runtime.*
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.layout.ContentScale
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import coil.compose.AsyncImage
+import coil.request.ImageRequest
+import com.google.firebase.firestore.FieldValue
+import com.google.firebase.firestore.FirebaseFirestore
+import com.unidagontor.retakid.ui.theme.*
+import kotlinx.coroutines.tasks.await
+import java.text.SimpleDateFormat
+import java.util.*
+import kotlinx.coroutines.launch
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun DetailLaporanScreen(
+    laporanId: String,
+    onBack: () -> Unit,
+    onConfirm: () -> Unit
+) {
+    val scope = rememberCoroutineScope()
+    var laporan by remember { mutableStateOf<LaporanItem?>(null) }
+    var isLoading by remember { mutableStateOf(true) }
+    var isConfirming by remember { mutableStateOf(false) }
+
+    LaunchedEffect(laporanId) {
+        try {
+            val doc = FirebaseFirestore.getInstance()
+                .collection("laporan")
+                .document(laporanId)
+                .get()
+                .await()
+
+            if (doc.exists()) {
+                val timestampLong = doc.get("timestamp")?.let {
+                    when (it) { is Long -> it; is Double -> it.toLong(); else -> 0L }
+                } ?: 0L
+                val terverifikasi = doc.get("terverifikasi")?.let {
+                    when (it) { is Long -> it.toInt(); is Double -> it.toInt(); else -> 0 }
+                } ?: 0
+
+                laporan = LaporanItem(
+                    id = doc.id,
+                    namaLokasi = doc.getString("namaLokasi") ?: "Tanpa Nama",
+                    status = doc.getString("status") ?: "AMAN",
+                    catatan = doc.getString("catatan") ?: "",
+                    fotoUrl = doc.getString("foto_url"),
+                    latitude = doc.getDouble("latitude") ?: 0.0,
+                    longitude = doc.getDouble("longitude") ?: 0.0,
+                    timestamp = formatDetailTimestamp(timestampLong),
+                    pelapor = doc.getString("pelapor") ?: "User",
+                    terverifikasi = terverifikasi
+                )
+            }
+        } catch (_: Exception) { }
+        isLoading = false
+    }
+
+    Scaffold(
+        topBar = {
+            TopAppBar(
+                title = { Text("Detail Laporan", fontSize = 18.sp) },
+                navigationIcon = {
+                    IconButton(onClick = onBack) {
+                        Icon(Icons.Default.ArrowBack, contentDescription = "Kembali")
+                    }
+                },
+                colors = TopAppBarDefaults.topAppBarColors(containerColor = GreenPrimary, titleContentColor = Color.White, navigationIconContentColor = Color.White)
+            )
+        }
+    ) { padding ->
+        if (isLoading) {
+            Box(modifier = Modifier.fillMaxSize().padding(padding), contentAlignment = Alignment.Center) {
+                CircularProgressIndicator(color = GreenPrimary)
+            }
+        } else if (laporan == null) {
+            Box(modifier = Modifier.fillMaxSize().padding(padding), contentAlignment = Alignment.Center) {
+                Text("Laporan tidak ditemukan", color = TextSecondary)
+            }
+        } else {
+            DetailContent(
+                laporan = laporan!!,
+                isConfirming = isConfirming,
+                onConfirm = {
+                    isConfirming = true
+                    scope.launch {
+                        try {
+                            FirebaseFirestore.getInstance()
+                                .collection("laporan")
+                                .document(laporanId)
+                                .update("terverifikasi", FieldValue.increment(1))
+                                .await()
+                        } catch (_: Exception) { }
+                        onConfirm()
+                    }
+                },
+                padding = padding
+            )
+        }
+    }
+}
+
+@Composable
+private fun DetailContent(
+    laporan: LaporanItem,
+    isConfirming: Boolean,
+    onConfirm: () -> Unit,
+    padding: PaddingValues
+) {
+    val context = LocalContext.current
+
+    val (statusColor, statusBg) = when (laporan.status) {
+        "BAHAYA" -> StatusBahaya to StatusBahayaBg
+        "WASPADA" -> StatusWaspada to StatusWaspadaBg
+        else -> StatusAman to StatusAmanBg
+    }
+
+    Column(
+        modifier = Modifier
+            .fillMaxSize()
+            .padding(padding)
+            .verticalScroll(rememberScrollState())
+    ) {
+        if (!laporan.fotoUrl.isNullOrBlank()) {
+            AsyncImage(
+                model = ImageRequest.Builder(context)
+                    .data(laporan.fotoUrl)
+                    .crossfade(true)
+                    .build(),
+                contentDescription = "Foto laporan",
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .height(260.dp)
+                    .background(Color.LightGray),
+                contentScale = ContentScale.Crop
+            )
+        }
+
+        Column(modifier = Modifier.padding(20.dp)) {
+            Row(
+                modifier = Modifier.fillMaxWidth(),
+                horizontalArrangement = Arrangement.SpaceBetween,
+                verticalAlignment = Alignment.CenterVertically
+            ) {
+                Row(verticalAlignment = Alignment.CenterVertically) {
+                    Icon(Icons.Default.LocationOn, contentDescription = null, tint = TextSecondary, modifier = Modifier.size(18.dp))
+                    Spacer(modifier = Modifier.width(4.dp))
+                    Text(laporan.namaLokasi, fontWeight = FontWeight.Bold, fontSize = 18.sp, color = TextPrimary)
+                }
+                Surface(color = statusBg, shape = RoundedCornerShape(6.dp)) {
+                    Text(
+                        laporan.status,
+                        modifier = Modifier.padding(horizontal = 12.dp, vertical = 4.dp),
+                        color = statusColor,
+                        fontSize = 13.sp,
+                        fontWeight = FontWeight.Bold
+                    )
+                }
+            }
+
+            Spacer(modifier = Modifier.height(12.dp))
+
+            HorizontalDivider()
+
+            Spacer(modifier = Modifier.height(12.dp))
+
+            Text("Catatan", fontWeight = FontWeight.SemiBold, fontSize = 14.sp, color = TextPrimary)
+            Spacer(modifier = Modifier.height(4.dp))
+            Text(laporan.catatan.ifBlank { "Tidak ada catatan" }, fontSize = 14.sp, color = TextSecondary)
+
+            Spacer(modifier = Modifier.height(16.dp))
+
+            Row(
+                modifier = Modifier.fillMaxWidth(),
+                horizontalArrangement = Arrangement.SpaceBetween
+            ) {
+                DetailInfoRow(icon = Icons.Default.Person, label = "Pelapor", value = laporan.pelapor)
+                DetailInfoRow(icon = Icons.Default.Schedule, label = "Waktu", value = laporan.timestamp)
+            }
+
+            Spacer(modifier = Modifier.height(12.dp))
+
+            Row(verticalAlignment = Alignment.CenterVertically) {
+                Icon(Icons.Default.LocationOn, contentDescription = null, tint = TextSecondary, modifier = Modifier.size(14.dp))
+                Spacer(modifier = Modifier.width(4.dp))
+                Text(
+                    "${"%.6f".format(laporan.latitude)}, ${"%.6f".format(laporan.longitude)}",
+                    fontSize = 13.sp,
+                    color = TextSecondary
+                )
+            }
+
+            Spacer(modifier = Modifier.height(24.dp))
+
+            Surface(
+                color = GreenSurface,
+                shape = RoundedCornerShape(12.dp),
+                modifier = Modifier.fillMaxWidth()
+            ) {
+                Column(
+                    modifier = Modifier.padding(16.dp),
+                    horizontalAlignment = Alignment.CenterHorizontally
+                ) {
+                    Text("Konfirmasi Warga", fontWeight = FontWeight.Bold, fontSize = 14.sp, color = TextPrimary)
+                    Spacer(modifier = Modifier.height(4.dp))
+                    Text(
+                        "${laporan.terverifikasi} konfirmasi",
+                        fontSize = 32.sp,
+                        fontWeight = FontWeight.Bold,
+                        color = GreenPrimary
+                    )
+                    Spacer(modifier = Modifier.height(12.dp))
+                    Button(
+                        onClick = onConfirm,
+                        enabled = !isConfirming,
+                        modifier = Modifier.fillMaxWidth().height(48.dp),
+                        colors = ButtonDefaults.buttonColors(containerColor = GreenPrimary),
+                        shape = RoundedCornerShape(12.dp)
+                    ) {
+                        if (isConfirming) {
+                            CircularProgressIndicator(modifier = Modifier.size(20.dp), color = Color.White)
+                        } else {
+                            Icon(Icons.Default.CheckCircle, contentDescription = null)
+                            Spacer(modifier = Modifier.width(8.dp))
+                            Text("Konfirmasi Laporan", fontWeight = FontWeight.Bold)
+                        }
+                    }
+                }
+            }
+
+            Spacer(modifier = Modifier.height(32.dp))
+        }
+    }
+}
+
+@Composable
+private fun DetailInfoRow(
+    icon: androidx.compose.ui.graphics.vector.ImageVector,
+    label: String,
+    value: String
+) {
+    Row(verticalAlignment = Alignment.CenterVertically) {
+        Icon(icon, contentDescription = null, tint = TextSecondary, modifier = Modifier.size(14.dp))
+        Spacer(modifier = Modifier.width(4.dp))
+        Column {
+            Text(label, fontSize = 11.sp, color = TextSecondary)
+            Text(value, fontSize = 14.sp, color = TextPrimary, fontWeight = FontWeight.Medium)
+        }
+    }
+}
+
+private fun formatDetailTimestamp(timestamp: Long): String {
+    if (timestamp == 0L) return "Baru saja"
+    val sdf = SimpleDateFormat("dd MMM yyyy, HH:mm", Locale.getDefault())
+    return sdf.format(Date(timestamp))
+}

--- a/mobile-app/app/src/main/java/com/unidagontor/retakid/ui/screens/MainScreens.kt
+++ b/mobile-app/app/src/main/java/com/unidagontor/retakid/ui/screens/MainScreens.kt
@@ -44,6 +44,7 @@ import androidx.compose.ui.viewinterop.AndroidView
 import androidx.core.content.ContextCompat
 import androidx.lifecycle.viewmodel.compose.viewModel
 import com.unidagontor.retakid.data.ml.DetectionResult
+import com.unidagontor.retakid.data.photo.ExifReader
 import com.unidagontor.retakid.ui.theme.*
 import com.unidagontor.retakid.ui.viewmodel.DeteksiStage
 import com.unidagontor.retakid.ui.viewmodel.DeteksiViewModel
@@ -82,7 +83,7 @@ fun DeteksiTab(vm: DeteksiViewModel = viewModel()) {
                 })
             }
             DeteksiStage.CAMERA -> {
-                CameraView(onImageCaptured = { vm.onImageCaptured(it) })
+                CameraView(onImageCaptured = { bitmap, exif -> vm.onImageCaptured(bitmap, exif) })
             }
             DeteksiStage.ANALYZING -> {
                 AnalyzingView()
@@ -172,7 +173,7 @@ fun InitialDetectionView(onStart: () -> Unit) {
 }
 
 @Composable
-fun CameraView(onImageCaptured: (Bitmap) -> Unit) {
+fun CameraView(onImageCaptured: (Bitmap, com.unidagontor.retakid.data.photo.ExifData?) -> Unit) {
     val context = LocalContext.current
     val lifecycleOwner = LocalLifecycleOwner.current
     val previewView = remember { PreviewView(context) }
@@ -222,13 +223,14 @@ fun CameraView(onImageCaptured: (Bitmap) -> Unit) {
                         object : ImageCapture.OnImageSavedCallback {
                             override fun onImageSaved(output: ImageCapture.OutputFileResults) {
                                 val uri = Uri.fromFile(file)
+                                val exifData = ExifReader.read(file.absolutePath)
                                 val bitmap = if (Build.VERSION.SDK_INT < 28) {
                                     MediaStore.Images.Media.getBitmap(context.contentResolver, uri)
                                 } else {
                                     val source = ImageDecoder.createSource(context.contentResolver, uri)
                                     ImageDecoder.decodeBitmap(source)
                                 }
-                                onImageCaptured(bitmap)
+                                onImageCaptured(bitmap, exifData)
                             }
 
                             override fun onError(exc: ImageCaptureException) {

--- a/mobile-app/app/src/main/java/com/unidagontor/retakid/ui/screens/MainScreens.kt
+++ b/mobile-app/app/src/main/java/com/unidagontor/retakid/ui/screens/MainScreens.kt
@@ -1,11 +1,16 @@
 package com.unidagontor.retakid.ui.screens
 
 import android.Manifest
+import android.content.ClipData
+import android.content.ClipboardManager
+import android.content.Context
+import android.content.Intent
 import android.graphics.Bitmap
 import android.graphics.ImageDecoder
 import android.net.Uri
 import android.os.Build
 import android.provider.MediaStore
+import android.widget.Toast
 import androidx.activity.compose.rememberLauncherForActivityResult
 import androidx.activity.result.contract.ActivityResultContracts
 import androidx.camera.core.CameraSelector
@@ -94,6 +99,7 @@ fun DeteksiTab(vm: DeteksiViewModel = viewModel()) {
                         confidence = displayConfidence,
                         report = state.riskFactorReport,
                         image = state.capturedImage,
+                        location = state.location,
                         onProceed = { vm.proceedToReport() },
                         onRetry = { vm.reset() }
                     )
@@ -286,9 +292,11 @@ fun ResultView(
     confidence: Float,
     report: com.unidagontor.retakid.data.risk.RiskFactorReport?,
     image: Bitmap?,
+    location: com.unidagontor.retakid.data.location.LocationData?,
     onProceed: () -> Unit,
     onRetry: () -> Unit
 ) {
+    val context = LocalContext.current
     Column(
         modifier = Modifier.fillMaxSize().padding(24.dp).verticalScroll(rememberScrollState()),
         horizontalAlignment = Alignment.CenterHorizontally
@@ -415,6 +423,96 @@ fun ResultView(
                         color = Color.White,
                         fontSize = 12.sp,
                         fontWeight = FontWeight.Bold
+                    )
+                }
+            }
+        }
+
+        // --- Action buttons based on status ---
+        when (result) {
+            DetectionResult.BAHAYA -> {
+                Spacer(modifier = Modifier.height(16.dp))
+                Button(
+                    onClick = {
+                        val intent = Intent(Intent.ACTION_DIAL).apply {
+                            data = Uri.parse("tel:112")
+                        }
+                        context.startActivity(intent)
+                    },
+                    modifier = Modifier.fillMaxWidth().height(50.dp),
+                    colors = ButtonDefaults.buttonColors(containerColor = StatusBahaya),
+                    shape = RoundedCornerShape(12.dp)
+                ) {
+                    Icon(Icons.Default.Phone, contentDescription = null)
+                    Spacer(modifier = Modifier.width(8.dp))
+                    Text("Hubungi BPBD (112)")
+                }
+            }
+            else -> {}
+        }
+
+        if (result != DetectionResult.AMAN) {
+            Spacer(modifier = Modifier.height(8.dp))
+
+            val shareContent = buildShareText(result, location, report)
+
+            OutlinedButton(
+                onClick = {
+                    val intent = Intent(Intent.ACTION_SEND).apply {
+                        type = "text/plain"
+                        putExtra(Intent.EXTRA_TEXT, shareContent)
+                        setPackage("com.whatsapp")
+                    }
+                    try {
+                        context.startActivity(intent)
+                    } catch (_: Exception) {
+                        val fallback = Intent.createChooser(intent.apply { setPackage(null) }, "Bagikan ke...")
+                        context.startActivity(fallback)
+                    }
+                },
+                modifier = Modifier.fillMaxWidth().height(50.dp),
+                shape = RoundedCornerShape(12.dp)
+            ) {
+                Icon(Icons.Default.Share, contentDescription = null)
+                Spacer(modifier = Modifier.width(8.dp))
+                Text("Bagikan ke WhatsApp")
+            }
+
+            if (result == DetectionResult.WASPADA) {
+                Spacer(modifier = Modifier.height(8.dp))
+                OutlinedButton(
+                    onClick = {
+                        val clipboard = context.getSystemService(Context.CLIPBOARD_SERVICE) as ClipboardManager
+                        val clip = ClipData.newPlainText("Laporan Retakan", buildShareText(result, location, report))
+                        clipboard.setPrimaryClip(clip)
+                        Toast.makeText(context, "Teks laporan disalin ke clipboard", Toast.LENGTH_SHORT).show()
+                    },
+                    modifier = Modifier.fillMaxWidth().height(50.dp),
+                    shape = RoundedCornerShape(12.dp)
+                ) {
+                    Icon(Icons.Default.ContentCopy, contentDescription = null)
+                    Spacer(modifier = Modifier.width(8.dp))
+                    Text("Laporkan ke RT / RW")
+                }
+            }
+        } else {
+            Spacer(modifier = Modifier.height(12.dp))
+            Surface(
+                color = StatusAman.copy(alpha = 0.1f),
+                shape = RoundedCornerShape(12.dp),
+                modifier = Modifier.fillMaxWidth()
+            ) {
+                Row(
+                    modifier = Modifier.padding(12.dp),
+                    verticalAlignment = Alignment.CenterVertically
+                ) {
+                    Icon(Icons.Default.Info, contentDescription = null, tint = StatusAman)
+                    Spacer(modifier = Modifier.width(12.dp))
+                    Text(
+                        "Pantau Berkala — Kondisi tanah masih aman, tetap waspada terutama saat hujan.",
+                        color = StatusAman,
+                        fontSize = 12.sp,
+                        fontWeight = FontWeight.Medium
                     )
                 }
             }
@@ -659,6 +757,34 @@ fun SuccessView(onFinish: () -> Unit) {
 
 
 
+
+private fun buildShareText(
+    result: DetectionResult,
+    location: com.unidagontor.retakid.data.location.LocationData?,
+    report: com.unidagontor.retakid.data.risk.RiskFactorReport?
+): String {
+    val status = result.label
+    val lat = location?.let { "%.6f".format(it.latitude) } ?: "-"
+    val lon = location?.let { "%.6f".format(it.longitude) } ?: "-"
+    val score = report?.let { "${"%.0f".format(it.finalScore * 100)}%" } ?: "?"
+
+    val factors = report?.factors?.joinToString("\n") { f ->
+        "• ${f.factor.displayName}: ${f.rawValue} ${f.riskLabel.emoji}"
+    } ?: ""
+
+    return buildString {
+        appendLine("Saya menemukan retakan tanah dengan status $status.")
+        appendLine("Koordinat: $lat, $lon")
+        appendLine("Skor Risiko: $score")
+        if (factors.isNotBlank()) {
+            appendLine()
+            appendLine("Faktor Lingkungan:")
+            append(factors)
+        }
+        appendLine()
+        append("Mohon tindak lanjut.")
+    }
+}
 
 @Composable
 fun ProfilTab() {

--- a/mobile-app/app/src/main/java/com/unidagontor/retakid/ui/screens/MainScreens.kt
+++ b/mobile-app/app/src/main/java/com/unidagontor/retakid/ui/screens/MainScreens.kt
@@ -23,6 +23,8 @@ import androidx.compose.animation.*
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.shape.RoundedCornerShape
@@ -48,6 +50,7 @@ import com.unidagontor.retakid.data.photo.ExifReader
 import com.unidagontor.retakid.ui.theme.*
 import com.unidagontor.retakid.ui.viewmodel.DeteksiStage
 import com.unidagontor.retakid.ui.viewmodel.DeteksiViewModel
+import com.unidagontor.retakid.ui.viewmodel.ProfilViewModel
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.*
 import java.io.File
@@ -789,12 +792,231 @@ private fun buildShareText(
 }
 
 @Composable
-fun ProfilTab() {
-    Column(modifier = Modifier.fillMaxSize().padding(16.dp)) {
-        Text("Adam Toyib Nur Wahid", fontSize = 20.sp, fontWeight = FontWeight.Bold)
-        Text("Poin: 150 | Badge: Relawan")
-        Spacer(modifier = Modifier.height(24.dp))
-        TextButton(onClick = { }, modifier = Modifier.fillMaxWidth()) { Text("Riwayat Laporan") }
-        TextButton(onClick = { }, modifier = Modifier.fillMaxWidth()) { Text("Panduan Kearifan Lokal") }
+fun ProfilTab(
+    onSignOut: () -> Unit = {},
+    onRiwayatClick: (String) -> Unit = {},
+    viewModel: ProfilViewModel = viewModel()
+) {
+    val state by viewModel.uiState.collectAsState()
+
+    Column(
+        modifier = Modifier.fillMaxSize().background(Surface)
+    ) {
+        // Header
+        Box(
+            modifier = Modifier
+                .fillMaxWidth()
+                .background(GreenPrimary)
+                .padding(24.dp)
+        ) {
+            Column(horizontalAlignment = Alignment.Start) {
+                Text("Profil Saya", fontSize = 22.sp, fontWeight = FontWeight.Bold, color = Color.White)
+                Spacer(modifier = Modifier.height(4.dp))
+                Text("Pantau kontribusi dan badge kamu", fontSize = 13.sp, color = Color.White.copy(alpha = 0.8f))
+            }
+        }
+
+        if (state.isLoading) {
+            Box(modifier = Modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
+                CircularProgressIndicator(color = GreenPrimary)
+            }
+        } else if (state.error != null) {
+            Box(modifier = Modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
+                Column(horizontalAlignment = Alignment.CenterHorizontally) {
+                    Text(state.error!!, color = TextSecondary, fontSize = 14.sp)
+                    Spacer(modifier = Modifier.height(16.dp))
+                    Button(onClick = { viewModel.loadProfile() }, colors = ButtonDefaults.buttonColors(containerColor = GreenPrimary)) {
+                        Text("Coba Lagi")
+                    }
+                }
+            }
+        } else {
+            LazyColumn(
+                modifier = Modifier.fillMaxSize(),
+                contentPadding = PaddingValues(16.dp),
+                verticalArrangement = Arrangement.spacedBy(12.dp)
+            ) {
+                // Avatar + Nama + Email
+                item {
+                    Surface(
+                        shape = RoundedCornerShape(16.dp),
+                        color = Color.White,
+                        modifier = Modifier.fillMaxWidth()
+                    ) {
+                        Row(
+                            modifier = Modifier.padding(20.dp),
+                            verticalAlignment = Alignment.CenterVertically
+                        ) {
+                            Box(
+                                modifier = Modifier
+                                    .size(64.dp)
+                                    .clip(CircleShape)
+                                    .background(GreenSurface),
+                                contentAlignment = Alignment.Center
+                            ) {
+                                Text(
+                                state.namaLengkap.take(1).uppercase(),
+                                fontSize = 28.sp,
+                                fontWeight = FontWeight.Bold,
+                                color = GreenPrimary
+                            )
+                        }
+                        Spacer(modifier = Modifier.width(16.dp))
+                        Column {
+                            Text(state.namaLengkap, fontWeight = FontWeight.Bold, fontSize = 18.sp, color = TextPrimary)
+                                    if (state.email.isNotEmpty()) {
+                                        Text(state.email, fontSize = 13.sp, color = TextSecondary)
+                                    }
+                                }
+                            }
+                        }
+                    }
+
+                    // Poin + Badge Card
+                    item {
+                        Surface(
+                            shape = RoundedCornerShape(16.dp),
+                            color = Color.White,
+                            modifier = Modifier.fillMaxWidth()
+                        ) {
+                            Row(
+                                modifier = Modifier.fillMaxWidth().padding(20.dp),
+                                horizontalArrangement = Arrangement.SpaceEvenly
+                            ) {
+                                StatItem(value = "${state.poin}", label = "Poin", color = GreenPrimary)
+                                StatItem(value = state.badge, label = "Badge", color = GreenPrimary)
+                                StatItem(value = "${state.totalLaporan}", label = "Laporan", color = GreenPrimary)
+                            }
+                        }
+                    }
+
+                    // Progress badge berikutnya
+                    item {
+                        Surface(
+                            shape = RoundedCornerShape(16.dp),
+                            color = Color.White,
+                            modifier = Modifier.fillMaxWidth()
+                        ) {
+                            Row(
+                                modifier = Modifier.padding(16.dp),
+                                verticalAlignment = Alignment.CenterVertically
+                            ) {
+                                Icon(Icons.Default.Star, contentDescription = null, tint = StatusWaspada, modifier = Modifier.size(18.dp))
+                                Spacer(modifier = Modifier.width(8.dp))
+                                Text("Badge berikutnya: ${state.nextBadge}", fontSize = 13.sp, color = TextSecondary)
+                            }
+                        }
+                    }
+
+                    // Riwayat Laporan header
+                    item {
+                        Text(
+                            "Riwayat Laporan",
+                            fontWeight = FontWeight.Bold,
+                            fontSize = 16.sp,
+                            color = TextPrimary,
+                            modifier = Modifier.padding(top = 8.dp, bottom = 4.dp)
+                        )
+                    }
+
+                    // Riwayat list
+                    if (state.riwayatList.isEmpty()) {
+                        item {
+                            Surface(shape = RoundedCornerShape(12.dp), color = Color.White, modifier = Modifier.fillMaxWidth()) {
+                                Text(
+                                    "Belum ada laporan. Mulai deteksi retakan dari tab Deteksi!",
+                                    modifier = Modifier.padding(20.dp),
+                                    fontSize = 14.sp,
+                                    color = TextSecondary,
+                                    textAlign = TextAlign.Center
+                                )
+                            }
+                        }
+                    } else {
+                        items(state.riwayatList) { item ->
+                            RiwayatCard(
+                                namaLokasi = item.namaLokasi,
+                                status = item.status,
+                                terverifikasi = item.terverifikasi,
+                                waktu = item.createdAt.take(10),
+                                onClick = { onRiwayatClick(item.id) }
+                            )
+                        }
+                    }
+
+                    // Logout
+                    item {
+                        Spacer(modifier = Modifier.height(8.dp))
+                        OutlinedButton(
+                            onClick = { viewModel.signOut { onSignOut() } },
+                            modifier = Modifier.fillMaxWidth().height(48.dp),
+                            colors = ButtonDefaults.outlinedButtonColors(contentColor = StatusBahaya),
+                            shape = RoundedCornerShape(12.dp)
+                        ) {
+                            Icon(Icons.Default.Logout, contentDescription = null)
+                            Spacer(modifier = Modifier.width(8.dp))
+                            Text("Keluar")
+                        }
+                        Spacer(modifier = Modifier.height(16.dp))
+                    }
+                }
+            }
+        }
+    }
+}
+
+@Composable
+private fun StatItem(value: String, label: String, color: Color) {
+    Column(horizontalAlignment = Alignment.CenterHorizontally) {
+        Text(value, fontWeight = FontWeight.Bold, fontSize = 22.sp, color = color)
+        Text(label, fontSize = 12.sp, color = TextSecondary)
+    }
+}
+
+@Composable
+private fun RiwayatCard(
+    namaLokasi: String,
+    status: String,
+    terverifikasi: Int,
+    waktu: String,
+    onClick: () -> Unit
+) {
+    val (statusColor, statusBg) = when (status) {
+        "BAHAYA" -> StatusBahaya to StatusBahayaBg
+        "WASPADA" -> StatusWaspada to StatusWaspadaBg
+        else -> StatusAman to StatusAmanBg
+    }
+
+    Card(
+        onClick = onClick,
+        modifier = Modifier.fillMaxWidth(),
+        shape = RoundedCornerShape(12.dp),
+        colors = CardDefaults.cardColors(containerColor = Color.White),
+        elevation = CardDefaults.cardElevation(1.dp)
+    ) {
+        Row(
+            modifier = Modifier.padding(14.dp),
+            verticalAlignment = Alignment.CenterVertically
+        ) {
+            Icon(Icons.Default.LocationOn, contentDescription = null, tint = TextSecondary, modifier = Modifier.size(16.dp))
+            Spacer(modifier = Modifier.width(6.dp))
+            Column(modifier = Modifier.weight(1f)) {
+                Text(namaLokasi, fontWeight = FontWeight.Medium, fontSize = 14.sp, color = TextPrimary)
+                Row(verticalAlignment = Alignment.CenterVertically) {
+                    Icon(Icons.Default.CheckCircle, contentDescription = null, tint = GreenPrimary, modifier = Modifier.size(11.dp))
+                    Text(" $terverifikasi", fontSize = 11.sp, color = GreenPrimary)
+                    Text(" · $waktu", fontSize = 11.sp, color = TextSecondary)
+                }
+            }
+            Surface(color = statusBg, shape = RoundedCornerShape(4.dp)) {
+                Text(
+                    status,
+                    modifier = Modifier.padding(horizontal = 8.dp, vertical = 2.dp),
+                    fontSize = 10.sp,
+                    fontWeight = FontWeight.Bold,
+                    color = statusColor
+                )
+            }
+        }
     }
 }

--- a/mobile-app/app/src/main/java/com/unidagontor/retakid/ui/screens/SplashScreen.kt
+++ b/mobile-app/app/src/main/java/com/unidagontor/retakid/ui/screens/SplashScreen.kt
@@ -1,5 +1,9 @@
 package com.unidagontor.retakid.ui.screens
 
+import android.Manifest
+import android.os.Build
+import androidx.activity.compose.rememberLauncherForActivityResult
+import androidx.activity.result.contract.ActivityResultContracts
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.fillMaxSize
@@ -9,18 +13,31 @@ import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.sp
 import kotlinx.coroutines.delay
 
 @Composable
 fun SplashScreen(onSplashFinished: () -> Unit) {
+    val context = LocalContext.current
+
+    val notifPermissionLauncher = rememberLauncherForActivityResult(
+        ActivityResultContracts.RequestPermission()
+    ) { _ -> }
+
     LaunchedEffect(Unit) {
-        delay(2000) // Tampil 2 detik
-        onSplashFinished() // Memanggil logika pengecekan di AppNavigation
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
+            notifPermissionLauncher.launch(Manifest.permission.POST_NOTIFICATIONS)
+        }
+    }
+
+    LaunchedEffect(Unit) {
+        delay(2000)
+        onSplashFinished()
     }
     Box(
-        modifier = Modifier.fillMaxSize().background(Color(0xFF4CAF50)), // Ganti dengan GreenPrimary jika error
+        modifier = Modifier.fillMaxSize().background(Color(0xFF4CAF50)),
         contentAlignment = Alignment.Center
     ) {
         Text("Retak.id", color = Color.White, fontSize = 40.sp, fontWeight = FontWeight.Bold)

--- a/mobile-app/app/src/main/java/com/unidagontor/retakid/ui/viewmodel/BerandaViewModel.kt
+++ b/mobile-app/app/src/main/java/com/unidagontor/retakid/ui/viewmodel/BerandaViewModel.kt
@@ -2,16 +2,35 @@ package com.unidagontor.retakid.ui.viewmodel
 
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
-import com.google.firebase.firestore.FirebaseFirestore
-import com.google.firebase.firestore.Query
+import com.unidagontor.retakid.data.SupabaseClient
 import com.unidagontor.retakid.ui.screens.LaporanItem
+import io.github.jan.supabase.postgrest.from
+import io.github.jan.supabase.postgrest.query.Order
+import io.github.jan.supabase.realtime.PostgresAction
+import io.github.jan.supabase.realtime.postgresChangeFlow
+import io.github.jan.supabase.realtime.realtime
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.launch
-import kotlinx.coroutines.tasks.await
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
 import java.text.SimpleDateFormat
 import java.util.*
+
+@Serializable
+data class LaporanDto(
+    val id: String,
+    @SerialName("nama_lokasi") val namaLokasi: String = "",
+    val status: String = "AMAN",
+    val catatan: String = "",
+    @SerialName("foto_url") val fotoUrl: String? = null,
+    val latitude: Double = 0.0,
+    val longitude: Double = 0.0,
+    @SerialName("created_at") val createdAt: String = "",
+    val pelapor: String = "",
+    val terverifikasi: Int = 0
+)
 
 data class BerandaState(
     val laporanList: List<LaporanItem> = emptyList(),
@@ -23,79 +42,73 @@ class BerandaViewModel : ViewModel() {
     private val _uiState = MutableStateFlow(BerandaState())
     val uiState: StateFlow<BerandaState> = _uiState.asStateFlow()
 
-    private val db = FirebaseFirestore.getInstance()
-
     init {
         fetchLaporan()
+        startRealtimeSubscription()
+    }
+
+    private fun startRealtimeSubscription() {
+        viewModelScope.launch {
+            try {
+                SupabaseClient.client.realtime["beranda"]
+                    .postgresChangeFlow<PostgresAction.All>(schema = "public") {
+                        table = "laporan"
+                    }
+                    .collect {
+                        fetchLaporan()
+                    }
+            } catch (_: Exception) { }
+        }
     }
 
     fun fetchLaporan() {
         viewModelScope.launch {
             _uiState.value = _uiState.value.copy(isLoading = true)
-            db.collection("laporan")
-                .orderBy("timestamp", Query.Direction.DESCENDING)
-                .addSnapshotListener { snapshot, e ->
-                    if (e != null) {
-                        _uiState.value = _uiState.value.copy(isLoading = false, error = e.message)
-                        return@addSnapshotListener
+            try {
+                val supabase = SupabaseClient.client
+                val items = supabase.from("laporan")
+                    .select { order("created_at", Order.DESCENDING) }
+                    .decodeList<LaporanDto>()
+                    .map { dto ->
+                        LaporanItem(
+                            id = dto.id,
+                            namaLokasi = dto.namaLokasi,
+                            status = dto.status,
+                            catatan = dto.catatan,
+                            fotoUrl = dto.fotoUrl,
+                            latitude = dto.latitude,
+                            longitude = dto.longitude,
+                            timestamp = formatTimestamp(parseIsoTimestamp(dto.createdAt)),
+                            pelapor = dto.pelapor,
+                            terverifikasi = dto.terverifikasi
+                        )
                     }
-
-                    if (snapshot != null) {
-                        val items = snapshot.documents.mapNotNull { doc ->
-                            try {
-                                val id = doc.id
-                                val namaLokasi = doc.getString("namaLokasi") ?: "Tanpa Nama"
-                                val status = doc.getString("status") ?: "AMAN"
-                                val catatan = doc.getString("catatan") ?: ""
-                                val fotoUrl = doc.getString("foto_url")
-                                val latitude = doc.getDouble("latitude") ?: 0.0
-                                val longitude = doc.getDouble("longitude") ?: 0.0
-                                val timestampLong = doc.get("timestamp")?.let {
-                                    when (it) {
-                                        is Long -> it
-                                        is Double -> it.toLong()
-                                        else -> 0L
-                                    }
-                                } ?: 0L
-                                val pelapor = doc.getString("pelapor") ?: "User"
-                                val terverifikasi = doc.get("terverifikasi")?.let {
-                                    when (it) {
-                                        is Long -> it.toInt()
-                                        is Double -> it.toInt()
-                                        else -> 0
-                                    }
-                                } ?: 0
-
-                                LaporanItem(
-                                    id = id,
-                                    namaLokasi = namaLokasi,
-                                    status = status,
-                                    catatan = catatan,
-                                    fotoUrl = fotoUrl,
-                                    latitude = latitude,
-                                    longitude = longitude,
-                                    timestamp = formatTimestamp(timestampLong),
-                                    pelapor = pelapor,
-                                    terverifikasi = terverifikasi
-                                )
-                            } catch (e: Exception) {
-                                null
-                            }
-                        }
-                        _uiState.value = BerandaState(laporanList = items, isLoading = false)
-                    }
-                }
+                _uiState.value = BerandaState(laporanList = items, isLoading = false)
+            } catch (e: Exception) {
+                _uiState.value = BerandaState(isLoading = false, error = e.message)
+            }
         }
     }
 
     fun confirmLaporan(laporanId: String) {
         viewModelScope.launch {
             try {
-                db.collection("laporan").document(laporanId)
-                    .update("terverifikasi", com.google.firebase.firestore.FieldValue.increment(1))
-                    .await()
+                val supabase = SupabaseClient.client
+                val current = supabase.from("laporan")
+                    .select { filter { eq("id", laporanId) } }
+                    .decodeSingle<LaporanDto>()
+                supabase.from("laporan").update({
+                    "terverifikasi" to (current.terverifikasi + 1)
+                }) { filter { eq("id", laporanId) } }
             } catch (_: Exception) { }
         }
+    }
+
+    private fun parseIsoTimestamp(iso: String): Long {
+        return try {
+            val sdf = SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss", Locale.getDefault())
+            sdf.parse(iso.take(19))?.time ?: 0L
+        } catch (_: Exception) { 0L }
     }
 
     private fun formatTimestamp(timestamp: Long): String {

--- a/mobile-app/app/src/main/java/com/unidagontor/retakid/ui/viewmodel/BerandaViewModel.kt
+++ b/mobile-app/app/src/main/java/com/unidagontor/retakid/ui/viewmodel/BerandaViewModel.kt
@@ -9,6 +9,7 @@ import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.launch
+import kotlinx.coroutines.tasks.await
 import java.text.SimpleDateFormat
 import java.util.*
 
@@ -46,6 +47,9 @@ class BerandaViewModel : ViewModel() {
                                 val namaLokasi = doc.getString("namaLokasi") ?: "Tanpa Nama"
                                 val status = doc.getString("status") ?: "AMAN"
                                 val catatan = doc.getString("catatan") ?: ""
+                                val fotoUrl = doc.getString("foto_url")
+                                val latitude = doc.getDouble("latitude") ?: 0.0
+                                val longitude = doc.getDouble("longitude") ?: 0.0
                                 val timestampLong = doc.get("timestamp")?.let {
                                     when (it) {
                                         is Long -> it
@@ -67,6 +71,9 @@ class BerandaViewModel : ViewModel() {
                                     namaLokasi = namaLokasi,
                                     status = status,
                                     catatan = catatan,
+                                    fotoUrl = fotoUrl,
+                                    latitude = latitude,
+                                    longitude = longitude,
                                     timestamp = formatTimestamp(timestampLong),
                                     pelapor = pelapor,
                                     terverifikasi = terverifikasi
@@ -78,6 +85,16 @@ class BerandaViewModel : ViewModel() {
                         _uiState.value = BerandaState(laporanList = items, isLoading = false)
                     }
                 }
+        }
+    }
+
+    fun confirmLaporan(laporanId: String) {
+        viewModelScope.launch {
+            try {
+                db.collection("laporan").document(laporanId)
+                    .update("terverifikasi", com.google.firebase.firestore.FieldValue.increment(1))
+                    .await()
+            } catch (_: Exception) { }
         }
     }
 

--- a/mobile-app/app/src/main/java/com/unidagontor/retakid/ui/viewmodel/DeteksiViewModel.kt
+++ b/mobile-app/app/src/main/java/com/unidagontor/retakid/ui/viewmodel/DeteksiViewModel.kt
@@ -4,7 +4,6 @@ import android.app.Application
 import android.graphics.Bitmap
 import androidx.lifecycle.AndroidViewModel
 import androidx.lifecycle.viewModelScope
-import com.google.firebase.firestore.FirebaseFirestore
 import com.unidagontor.retakid.data.elevation.ElevationData
 import com.unidagontor.retakid.data.elevation.ElevationService
 import com.unidagontor.retakid.data.elevation.SlopeCalculator
@@ -28,11 +27,22 @@ import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
-import kotlinx.coroutines.tasks.await
 import kotlinx.coroutines.withContext
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
 import kotlinx.coroutines.withTimeoutOrNull
 import java.text.SimpleDateFormat
 import java.util.*
+
+@Serializable
+data class LaporanInsertDto(
+    @SerialName("nama_lokasi") val namaLokasi: String,
+    val status: String,
+    val catatan: String,
+    val latitude: Double,
+    val longitude: Double,
+    val pelapor: String,
+)
 
 enum class DeteksiStage {
     INITIAL,
@@ -61,7 +71,6 @@ class DeteksiViewModel(application: Application) : AndroidViewModel(application)
 
     private val mlAnalyzer = com.unidagontor.retakid.data.ml.TFLiteMLAnalyzer(application)
     private val locationService = LocationService(application)
-    private val db = FirebaseFirestore.getInstance()
 
     fun startDetection() {
         _uiState.update { it.copy(stage = DeteksiStage.CAMERA, error = null) }
@@ -155,29 +164,24 @@ class DeteksiViewModel(application: Application) : AndroidViewModel(application)
 
         viewModelScope.launch {
             try {
+                val supabase = SupabaseClient.client
+                val userId = supabase.auth.currentUserOrNull()?.id ?: return@launch
                 val finalLocation = state.location ?: locationService.getCurrentLocation()
 
-                val report = hashMapOf(
-                    "namaLokasi" to namaLokasi,
-                    "status" to finalResult.name,
-                    "catatan" to catatan,
-                    "latitude" to (finalLocation?.latitude ?: 0.0),
-                    "longitude" to (finalLocation?.longitude ?: 0.0),
-                    "timestamp" to System.currentTimeMillis(),
-                    "pelapor" to "User",
-                    "terverifikasi" to 0
+                val dto = LaporanInsertDto(
+                    namaLokasi = namaLokasi,
+                    status = finalResult.name,
+                    catatan = catatan,
+                    latitude = finalLocation?.latitude ?: 0.0,
+                    longitude = finalLocation?.longitude ?: 0.0,
+                    pelapor = userId,
                 )
-
-                db.collection("laporan")
-                    .add(report)
-                    .await()
+                supabase.from("laporan").insert(dto)
 
                 try {
-                    val supabase = SupabaseClient.client
-                    val userId = supabase.auth.currentUserOrNull()?.id ?: return@launch
                     val current = supabase.from("profiles")
                         .select { filter { eq("id", userId) } }
-                        .decodeSingle<com.unidagontor.retakid.ui.viewmodel.ProfileDto>()
+                        .decodeSingle<ProfileDto>()
                     supabase.from("profiles").update({
                         "poin" to (current.poin + 10)
                     }) { filter { eq("id", userId) } }

--- a/mobile-app/app/src/main/java/com/unidagontor/retakid/ui/viewmodel/DeteksiViewModel.kt
+++ b/mobile-app/app/src/main/java/com/unidagontor/retakid/ui/viewmodel/DeteksiViewModel.kt
@@ -5,9 +5,11 @@ import android.graphics.Bitmap
 import androidx.lifecycle.AndroidViewModel
 import androidx.lifecycle.viewModelScope
 import com.google.firebase.firestore.FirebaseFirestore
+import com.unidagontor.retakid.data.elevation.ElevationData
 import com.unidagontor.retakid.data.elevation.ElevationService
 import com.unidagontor.retakid.data.elevation.SlopeCalculator
 import com.unidagontor.retakid.data.location.LocationData
+import com.unidagontor.retakid.data.photo.ExifData
 import com.unidagontor.retakid.data.location.LocationService
 import com.unidagontor.retakid.data.ml.DetectionResult
 import com.unidagontor.retakid.data.ml.MLResult
@@ -45,6 +47,7 @@ data class DeteksiState(
     val mlResult: MLResult? = null,
     val riskFactorReport: RiskFactorReport? = null,
     val location: LocationData? = null,
+    val exifData: ExifData? = null,
     val isSubmitting: Boolean = false,
     val error: String? = null
 )
@@ -61,25 +64,33 @@ class DeteksiViewModel(application: Application) : AndroidViewModel(application)
         _uiState.update { it.copy(stage = DeteksiStage.CAMERA, error = null) }
     }
 
-    fun onImageCaptured(bitmap: Bitmap) {
+    fun onImageCaptured(bitmap: Bitmap, exifData: ExifData? = null) {
         _uiState.update { it.copy(capturedImage = bitmap, stage = DeteksiStage.ANALYZING) }
-        analyzeImage(bitmap)
+        analyzeImage(bitmap, exifData)
     }
 
-    private fun analyzeImage(bitmap: Bitmap) {
+    private fun analyzeImage(bitmap: Bitmap, exifData: ExifData?) {
         viewModelScope.launch {
             try {
                 val mlResult = mlAnalyzer.analyzeImage(bitmap)
                 _uiState.update { it.copy(mlResult = mlResult, stage = DeteksiStage.ANALYZING_ENV) }
-                fetchEnvironmentalFactors(mlResult)
+                fetchEnvironmentalFactors(mlResult, exifData)
             } catch (e: Exception) {
                 _uiState.update { it.copy(error = "Gagal menganalisis gambar: ${e.message}", stage = DeteksiStage.INITIAL) }
             }
         }
     }
 
-    private suspend fun fetchEnvironmentalFactors(mlResult: MLResult) {
-        val location = locationService.getCurrentLocation()
+    private suspend fun fetchEnvironmentalFactors(mlResult: MLResult, exifData: ExifData?) {
+        _uiState.update { it.copy(exifData = exifData) }
+
+        val exifLocation = exifData?.let {
+            if (it.latitude != null && it.longitude != null)
+                LocationData(it.latitude, it.longitude)
+            else null
+        }
+
+        val location = exifLocation ?: locationService.getCurrentLocation()
         _uiState.update { it.copy(location = location) }
 
         val report = withContext(Dispatchers.IO) {
@@ -95,15 +106,19 @@ class DeteksiViewModel(application: Application) : AndroidViewModel(application)
 
             withTimeoutOrNull(5000L) {
                 coroutineScope {
-                    val elevationDeferred = async { ElevationService.getElevation(lat, lon) }
+                    val exifElevation = exifData?.altitudeMeters?.let { ElevationData(it) }
+
+                    val apiElevationDeferred = async { ElevationService.getElevation(lat, lon) }
                     val weatherDeferred = async { WeatherApiService.getCurrentWeather().getOrNull() }
                     val soilDeferred = async { SoilTypeService.getSoilType(lat, lon) }
 
-                    val elevation = elevationDeferred.await()
+                    val apiElevation = apiElevationDeferred.await()
                     val weather = weatherDeferred.await()
                     val soil = soilDeferred.await()
 
-                    val slope = if (elevation != null) {
+                    val elevation = exifElevation ?: apiElevation
+
+                    val slope = if (apiElevation != null) {
                         SlopeCalculator.calculateSlope(lat, lon)
                     } else null
 

--- a/mobile-app/app/src/main/java/com/unidagontor/retakid/ui/viewmodel/DeteksiViewModel.kt
+++ b/mobile-app/app/src/main/java/com/unidagontor/retakid/ui/viewmodel/DeteksiViewModel.kt
@@ -11,6 +11,9 @@ import com.unidagontor.retakid.data.elevation.SlopeCalculator
 import com.unidagontor.retakid.data.location.LocationData
 import com.unidagontor.retakid.data.photo.ExifData
 import com.unidagontor.retakid.data.location.LocationService
+import com.unidagontor.retakid.data.SupabaseClient
+import io.github.jan.supabase.auth.auth
+import io.github.jan.supabase.postgrest.from
 import com.unidagontor.retakid.data.ml.DetectionResult
 import com.unidagontor.retakid.data.ml.MLResult
 import com.unidagontor.retakid.data.risk.MultiFactorRiskEngine
@@ -168,6 +171,17 @@ class DeteksiViewModel(application: Application) : AndroidViewModel(application)
                 db.collection("laporan")
                     .add(report)
                     .await()
+
+                try {
+                    val supabase = SupabaseClient.client
+                    val userId = supabase.auth.currentUserOrNull()?.id ?: return@launch
+                    val current = supabase.from("profiles")
+                        .select { filter { eq("id", userId) } }
+                        .decodeSingle<com.unidagontor.retakid.ui.viewmodel.ProfileDto>()
+                    supabase.from("profiles").update({
+                        "poin" to (current.poin + 10)
+                    }) { filter { eq("id", userId) } }
+                } catch (_: Exception) { }
 
                 _uiState.update { it.copy(isSubmitting = false, stage = DeteksiStage.SUCCESS) }
             } catch (e: Exception) {

--- a/mobile-app/app/src/main/java/com/unidagontor/retakid/ui/viewmodel/Profilviewmodel.kt
+++ b/mobile-app/app/src/main/java/com/unidagontor/retakid/ui/viewmodel/Profilviewmodel.kt
@@ -5,6 +5,7 @@ import androidx.lifecycle.viewModelScope
 import com.unidagontor.retakid.data.SupabaseClient
 import io.github.jan.supabase.auth.auth
 import io.github.jan.supabase.postgrest.from
+import kotlinx.coroutines.async
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
@@ -13,7 +14,6 @@ import kotlinx.coroutines.launch
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 
-// ─── DTO dari tabel profiles ─────────────────────────────────
 @Serializable
 data class ProfileDto(
     val id             : String,
@@ -24,19 +24,36 @@ data class ProfileDto(
     val badge          : String = "Warga"
 )
 
-// ─── UI State ─────────────────────────────────────────────────
-data class ProfilState(
-    val namaLengkap : String  = "",
-    val email       : String  = "",
-    val noTelepon   : String  = "",
-    val alamat      : String  = "",
-    val badge       : String  = "Warga",
-    val poin        : Int     = 0,
-    val isLoading   : Boolean = true,
-    val error       : String? = null
+@Serializable
+data class LaporanRiwayatDto(
+    val id: String,
+    @SerialName("nama_lokasi") val namaLokasi: String = "",
+    val status: String = "AMAN",
+    val catatan: String = "",
+    @SerialName("created_at") val createdAt: String = "",
+    val terverifikasi: Int = 0
 )
 
-// ─── ViewModel ────────────────────────────────────────────────
+data class ProfilState(
+    val namaLengkap : String = "",
+    val email       : String = "",
+    val noTelepon   : String = "",
+    val alamat      : String = "",
+    val badge       : String = "Warga",
+    val poin        : Int = 0,
+    val totalLaporan: Int = 0,
+    val riwayatList : List<LaporanRiwayatDto> = emptyList(),
+    val isLoading   : Boolean = true,
+    val error       : String? = null
+) {
+    val nextBadge: String get() = when {
+        totalLaporan < 5 -> "Relawan (5 laporan)"
+        totalLaporan < 20 -> "Pelindung (20 laporan)"
+        totalLaporan < 50 -> "Pahlawan Desa (50 laporan)"
+        else -> "★ Pahlawan Desa — maksimal"
+    }
+}
+
 class ProfilViewModel : ViewModel() {
 
     private val _uiState = MutableStateFlow(ProfilState())
@@ -51,26 +68,50 @@ class ProfilViewModel : ViewModel() {
             _uiState.update { it.copy(isLoading = true, error = null) }
             try {
                 val supabase = SupabaseClient.client
-                val user     = supabase.auth.currentUserOrNull()
+                val user = supabase.auth.currentUserOrNull()
                     ?: run {
                         _uiState.update { it.copy(isLoading = false, error = "Sesi tidak ditemukan.") }
                         return@launch
                     }
 
-                val profile = supabase
-                    .from("profiles")
-                    .select { filter { eq("id", user.id) } }
-                    .decodeSingle<ProfileDto>()
+                val profileDeferred = async { 
+                    supabase.from("profiles")
+                        .select { filter { eq("id", user.id) } }
+                        .decodeSingle<ProfileDto>()
+                }
+
+                val riwayatDeferred = async {
+                    supabase.from("laporan")
+                        .select {
+                            filter { eq("pelapor", user.id) }
+                            order("created_at", io.github.jan.supabase.postgrest.query.Order.DESCENDING)
+                            limit(20)
+                        }
+                        .decodeList<LaporanRiwayatDto>()
+                }
+
+                val profile = profileDeferred.await()
+                val riwayat = riwayatDeferred.await()
+                val totalLaporan = riwayat.size
+
+                val badge = when {
+                    totalLaporan >= 50 -> "Pahlawan Desa"
+                    totalLaporan >= 20 -> "Pelindung"
+                    totalLaporan >= 5 -> "Relawan"
+                    else -> "Pemula"
+                }
 
                 _uiState.update {
                     it.copy(
                         namaLengkap = profile.namaLengkap.ifEmpty { "Pengguna" },
-                        email       = user.email ?: "",
-                        noTelepon   = profile.noTelepon ?: "",
-                        alamat      = profile.alamat    ?: "",
-                        badge       = profile.badge,
-                        poin        = profile.poin,
-                        isLoading   = false
+                        email = user.email ?: "",
+                        noTelepon = profile.noTelepon ?: "",
+                        alamat = profile.alamat ?: "",
+                        badge = badge,
+                        poin = profile.poin,
+                        totalLaporan = totalLaporan,
+                        riwayatList = riwayat,
+                        isLoading = false
                     )
                 }
             } catch (e: Exception) {
@@ -84,8 +125,7 @@ class ProfilViewModel : ViewModel() {
             try {
                 SupabaseClient.client.auth.signOut()
                 onSuccess()
-            } catch (e: Exception) {
-                // Tetap logout dari sisi client meski network error
+            } catch (_: Exception) {
                 onSuccess()
             }
         }

--- a/mobile-app/build.gradle.kts
+++ b/mobile-app/build.gradle.kts
@@ -2,5 +2,4 @@
 plugins {
     alias(libs.plugins.android.application) apply false
     alias(libs.plugins.kotlin.compose) apply false
-    id("com.google.gms.google-services") version "4.4.4" apply false
 }

--- a/mobile-app/gradle/libs.versions.toml
+++ b/mobile-app/gradle/libs.versions.toml
@@ -9,6 +9,7 @@ activityCompose = "1.8.0"
 kotlin = "2.2.10"
 composeBom = "2026.02.01"
 navigationCompose = "2.9.8"
+supabase = "2.6.1"
 
 [libraries]
 androidx-core-ktx = { group = "androidx.core", name = "core-ktx", version.ref = "coreKtx" }
@@ -26,6 +27,12 @@ androidx-compose-ui-test-manifest = { group = "androidx.compose.ui", name = "ui-
 androidx-compose-ui-test-junit4 = { group = "androidx.compose.ui", name = "ui-test-junit4" }
 androidx-compose-material3 = { group = "androidx.compose.material3", name = "material3" }
 androidx-navigation-compose = { group = "androidx.navigation", name = "navigation-compose", version.ref = "navigationCompose" }
+supabase-bom = { group = "io.github.jan-tennert.supabase", name = "bom", version.ref = "supabase" }
+supabase-common = { group = "io.github.jan-tennert.supabase", name = "supabase-common" }
+supabase-auth = { group = "io.github.jan-tennert.supabase", name = "supabase-auth" }
+supabase-postgrest = { group = "io.github.jan-tennert.supabase", name = "supabase-postgrest-kt" }
+supabase-storage = { group = "io.github.jan-tennert.supabase", name = "supabase-storage-kt" }
+supabase-realtime = { group = "io.github.jan-tennert.supabase", name = "supabase-realtime-kt" }
 
 [plugins]
 android-application = { id = "com.android.application", version.ref = "agp" }

--- a/mobile-app/scripts/build-apk.sh
+++ b/mobile-app/scripts/build-apk.sh
@@ -1,0 +1,18 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+cd "$(dirname "$0")/.."
+
+echo "==> Building RetakID release APK..."
+./gradlew assembleRelease
+
+APK="app/build/outputs/apk/release/app-release.apk"
+DEST="retakid-v1.1.0.apk"
+
+if [ -f "$APK" ]; then
+  cp "$APK" "$DEST"
+  echo "==> APK built: $DEST"
+else
+  echo "==> Build failed or APK not found at $APK"
+  exit 1
+fi


### PR DESCRIPTION
## Summary

- **CS6 (#50)**: Profil pengguna with Supabase SDK
- **Firebase→Supabase**: Migrate remaining Firestore code to Supabase PostgREST
- Stacked on PR #96 (C4.2, C4.1, RF7, CS5) and PR #98 (CS4)

## CS6 Changes (Profil Pengguna)

- **ProfilViewModel**: Fetch `totalLaporan` from Supabase, badge logic (Pemula / Relawan / Pelindung / Pahlawan Desa), riwayat laporan list
- **ProfilTab**: Rewrite with real data — avatar, poin, badge, next-badge progress bar, riwayat items, sign-out button
- **DeteksiViewModel**: `+10` poin to user `profiles` on laporan submit
- **AppNavigation**: Wire `ProfilTab.onSignOut` → login, `onRiwayatClick` → detail navigation

## Firebase→Supabase Migration

| File | Before | After |
|------|--------|-------|
| `DeteksiViewModel.kt` | Firestore `laporan.add()` | `SupabaseClient.client.from("laporan").insert()` |
| `BerandaViewModel.kt` | Firestore `addSnapshotListener` + `FieldValue.increment` | Supabase `select()` + Realtime subscription + read-then-update |
| `DetailLaporanScreen.kt` | Firestore `document().get()` + `FieldValue.increment` | Supabase `select()` + read-then-update |
| `build.gradle.kts` (root+app) | `google-services` plugin | Removed |
| `proguard-rules.pro` | Firebase keep rules | Removed |

All `com.google.firebase.*` imports, `FirebaseFirestore`, `FieldValue`, and `kotlinx.coroutines.tasks.await` eliminated from the codebase.

## Badge Tiers

| Range | Badge |
|-------|-------|
| 0 laporan | Pemula |
| 5+ | Relawan |
| 20+ | Pelindung |
| 50+ | Pahlawan Desa |

## Related Issues
Closes #50

Depends on #96 and #98.